### PR TITLE
Allow configuring mention only rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## unreleased
+
+### Added
+
+* Allow configuring mention only rooms. This allows joining Middleman to
+  rooms with lots of discussion. Messages in a room in this list will only
+  be relayed to the management room if the Middleman user is mentioned in the
+  message.
+
 ## v0.1.0 - 2020-12-19
 
 Initial version with the following features

--- a/middleman/config.py
+++ b/middleman/config.py
@@ -87,6 +87,7 @@ class Config(object):
         self.user_id = self._get_cfg(["matrix", "user_id"], required=True)
         if not re.match("@.*:.*", self.user_id):
             raise ConfigError("matrix.user_id must be in the form @name:domain")
+        self.user_localpart = self.user_id.split(":")[0][1:]
 
         self.user_password = self._get_cfg(["matrix", "user_password"], required=False)
         self.user_token = self._get_cfg(["matrix", "user_token"], required=False)

--- a/middleman/config.py
+++ b/middleman/config.py
@@ -106,6 +106,7 @@ class Config(object):
         self.management_room_id = self.management_room if self.management_room.startswith("!") else None
         self.anonymise_senders = self._get_cfg(["middleman", "anonymise_senders"], required=False, default=False)
         self.welcome_message = self._get_cfg(["middleman", "welcome_message"], required=False)
+        self.mention_only_rooms = self._get_cfg(["middleman", "mention_only_rooms"], required=False, default=[])
 
     def _get_cfg(
         self, path: List[str], default: Any = None, required: bool = True,

--- a/middleman/message_responses.py
+++ b/middleman/message_responses.py
@@ -93,7 +93,9 @@ class Message(object):
         # First check if we want to relay this
         if self.is_mention_only_room([self.room.canonical_alias, self.room.room_id]):
             # Did we get mentioned?
-            if self.config.user_id not in get_mentions(self.message_content):
+            mentioned = self.config.user_id in get_mentions(self.message_content) or \
+                        self.message_content.find(self.config.user_localpart) > -1
+            if not mentioned:
                 logger.debug("Skipping message %s in room %s as it's set to only relay on mention and we were not "
                              "mentioned.", self.event.event_id, self.room.room_id)
                 return

--- a/middleman/utils.py
+++ b/middleman/utils.py
@@ -1,9 +1,15 @@
+import re
 import time
 
-from typing import Optional
+from typing import Optional, List
 
 # noinspection PyPackageRequirements
 import nio
+
+
+# Domain part from https://stackoverflow.com/a/106223/1489738
+USER_ID_REGEX = r"@[a-z0-9_=\/\-\.]*:(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9]" \
+                r"[A-Za-z0-9\-]*[A-Za-z0-9])*"
 
 
 def get_in_reply_to(event: nio.Event) -> Optional[str]:
@@ -11,6 +17,14 @@ def get_in_reply_to(event: nio.Event) -> Optional[str]:
     Pulls an in reply to event ID from an event, if any.
     """
     return event.source.get("content", {}).get("m.relates_to", {}).get("m.in_reply_to", {}).get("event_id")
+
+
+def get_mentions(text: str) -> List[str]:
+    """
+    Get mentions in a message.
+    """
+    matches = re.finditer(USER_ID_REGEX, text, re.MULTILINE)
+    return list({match.group() for match in matches})
 
 
 async def with_ratelimit(client, method, *args, **kwargs):

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -56,6 +56,8 @@ storage:
 logging:
   # Logging level
   # Allowed levels are 'INFO', 'WARNING', 'ERROR', 'DEBUG' where DEBUG is most verbose
+  # NOTE! DEBUG will print out all messages to the logs which could be a bad privacy
+  # thing - only use it to actually debug!
   level: INFO
   # Configure logging to a file
   file_logging:

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -35,6 +35,11 @@ middleman:
     Hello! I'm Middleman, a bot. I will relay your message forward to the maintainers of this
     bot. When they reply, you will see the message here. Ps. Sorry, images are not currently
     supported, text only please!
+  # List of rooms to only relay messages from when explicitly mentioned
+  # Any rooms here (alias or ID) will have messages relayed to the management
+  # room only if the bot is mentioned in the message. This allows joining the bot
+  # to rooms with a large amount of messages for support needs, for example.
+  mention_only_rooms: []
 
 storage:
   # The database connection string


### PR DESCRIPTION
Allow configuring mention only rooms. This allows joining Middleman to
rooms with lots of discussion. Messages in a room in this list will only
be relayed to the management room if the Middleman user is mentioned in the
message.

Closes #2