### PR TITLE
add support for media messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# vscode
+.vscode/
+
 # PyCharm
 .idea/
 

--- a/middleman/chat_functions.py
+++ b/middleman/chat_functions.py
@@ -119,3 +119,63 @@ async def send_reaction(
     except (LocalProtocolError, SendRetryError) as ex:
         logger.exception(f"Unable to send reaction to {event_id}")
         return f"Failed to send reaction: {ex}"
+
+
+async def send_media_to_room(
+    client: AsyncClient, room: str, media_type: str, body: str, media_url: str = None,
+    media_file: dict = None, media_info: dict = None, reply_to_event_id: str = None,
+) -> Union[RoomSendResponse, RoomSendError, str]:
+    """Send media to a matrix room
+
+    Args:
+        client (nio.AsyncClient): The client to communicate to matrix with
+
+        room (str): The ID or alias of the room to send the message to
+
+        body (str): The media body
+
+        media_info (dict): The media url and metadata
+
+        reply_to_event_id (str): Optional event ID that this message is a reply to.
+    """
+    try:
+        room_id = await get_room_id(client, room, logger)
+    except ValueError as ex:
+        return str(ex)
+    
+    if not (media_url or media_file):
+        logger.warning(f"Empty media url for room identifier: {room}")
+        return "Empty media url"
+
+    content = {
+        "msgtype": media_type,
+        "body": body,
+    }
+
+    if media_url:
+        content.update({"url": media_url})
+
+    if media_file:
+        content.update({"file": media_file})
+
+    if media_info:
+        content.update({"info": media_info})
+
+    # We don't store the original message content so cannot provide the fallback, unfortunately
+    if reply_to_event_id:
+        content["m.relates_to"] = {
+            "m.in_reply_to": {
+                "event_id": reply_to_event_id,
+            },
+        }
+
+    try:
+        return await client.room_send(
+            room_id,
+            "m.room.message",
+            content,
+            ignore_unverified_devices=True,
+        )
+    except (LocalProtocolError, SendRetryError) as ex:
+        logger.exception(f"Unable to send media response to {room_id}")
+        return f"Failed to send media: {ex}"

--- a/middleman/config.py
+++ b/middleman/config.py
@@ -134,6 +134,7 @@ class Config(object):
         self.confirm_reaction = self._get_cfg(["middleman", "confirm_reaction", "enabled"], required=False, default=False)
         self.confirm_reaction_success = self._get_cfg(["middleman", "confirm_reaction", "success"], required=False, default="✔️")
         self.confirm_reaction_fail = self._get_cfg(["middleman", "confirm_reaction", "fail"], required=False, default="❗")
+        self.relay_management_media = self._get_cfg(["middleman", "relay_management_media"], required=False, default=False)
 
     def _get_cfg(
         self, path: List[str], default: Any = None, required: bool = True,

--- a/middleman/main.py
+++ b/middleman/main.py
@@ -14,11 +14,13 @@ from nio import (
     LocalProtocolError,
     LoginError,
     MegolmEvent,
+    RoomEncryptedMedia,
     RoomKeyEvent,
     RoomMemberEvent,
     RoomMessageFormatted,
     RoomMessageNotice,
     RoomMessageText,
+    RoomMessageMedia,
     RoomResolveAliasResponse,
 )
 
@@ -60,6 +62,8 @@ async def main(config: Config):
     client.add_event_callback(callbacks.member, (RoomMemberEvent,))
     # noinspection PyTypeChecker
     client.add_event_callback(callbacks.message, (RoomMessageText, RoomMessageNotice, RoomMessageFormatted))
+    # noinspection PyTypeChecker
+    client.add_event_callback(callbacks.media, (RoomMessageMedia, RoomEncryptedMedia))
     # noinspection PyTypeChecker
     client.add_event_callback(callbacks.invite, (InviteMemberEvent,))
     # noinspection PyTypeChecker

--- a/middleman/media_responses.py
+++ b/middleman/media_responses.py
@@ -1,0 +1,176 @@
+import logging
+from typing import List
+
+# noinspection PyPackageRequirements
+from nio import RoomSendResponse, RoomSendError
+
+from middleman.chat_functions import send_media_to_room, send_reaction, send_text_to_room
+from middleman.utils import get_in_reply_to
+
+logger = logging.getLogger(__name__)
+
+media_name = {
+    "m.image": "image",
+    "m.audio": "audio",
+    "m.video": "video",
+    "m.file": "file",
+}
+
+class Media(object):
+    def __init__(self, client, store, config, media_type, body, media_url, media_file, media_info, room, event):
+        """Initialize a new Media
+
+        Args:
+            client (nio.AsyncClient): nio client used to interact with matrix
+
+            store (Storage): Bot storage
+
+            config (Config): Bot configuration parameters
+
+            media_type (str): The type of the media
+
+            body (str): The body of the media
+
+            media_url (str): The url of the media
+
+            media_file (str): The url of the encrypted media
+
+            media_info (str): The metadata of the media
+
+            room (nio.rooms.MatrixRoom): The room the event came from
+
+            event (nio.events.room_events.RoomMessageMedia): The event defining the media
+        """
+        self.client = client
+        self.store = store
+        self.config = config
+        self.room = room
+        self.event = event
+        self.media_type = media_type
+        self.body = body
+        self.media_url = media_url
+        self.media_file = media_file
+        self.media_info = media_info
+
+
+    async def handle_management_room_media(self):
+        reply_to = get_in_reply_to(self.event)
+
+        if reply_to and self.config.relay_management_media:
+            # Send back to original sender
+            message = self.store.get_message_by_management_event_id(reply_to)
+            if message:
+                # Relay back to original sender
+                response = await send_media_to_room(
+                    self.client,
+                    message["room_id"],
+                    self.media_type,
+                    self.body,
+                    self.media_url,
+                    self.media_file,
+                    self.media_info,
+                    reply_to_event_id=message["event_id"],
+                )
+                if isinstance(response, RoomSendResponse):
+                    # Store our outbound reply so we can reference it later
+                    self.store.store_message(
+                        event_id=response.event_id,
+                        management_event_id=self.event.event_id,
+                        room_id=message["room_id"],
+                    )
+                    if self.config.confirm_reaction:
+                        management_room_text = self.config.confirm_reaction_success
+                    elif self.config.anonymise_senders:
+                        management_room_text = f"{media_name[self.media_type]} delivered back to the sender."
+                    else:
+                        management_room_text = f"{media_name[self.media_type]} delivered back to the sender in room {message['room_id']}."
+                    logger.info(f"{media_name[self.media_type]} {self.event.event_id} relayed back to the original sender")
+                else:
+                    if self.config.confirm_reaction:
+                        management_room_text = self.config.confirm_reaction_fail
+                    else:
+                        management_room_text = f"Failed to send {media_name[self.media_type]} back to sender:" \
+                            f"{response.message if isinstance(response, RoomSendError) else response}"
+                    logger.warning(management_room_text)
+                # Confirm in management room
+                if self.config.confirm_reaction:
+                    await send_reaction(
+                        self.client,
+                        self.room.room_id,
+                        self.event.event_id,
+                        management_room_text
+                    )
+                else:
+                    await send_text_to_room(
+                        self.client,
+                        self.room.room_id,
+                        management_room_text,
+                        True,
+                    )
+            else:
+                logger.debug(
+                    f"Skipping {media_name[self.media_type]} {self.event.event_id} which is not a reply to one of our relay messages",
+                )
+        else:
+            logger.debug(f"Skipping {self.event.event_id} reply {media_name[self.media_type]}")
+
+    def is_mention_only_room(self, identifiers: List[str], is_named: bool) -> bool:
+        """
+        Check if this room is only if mentioned.
+        """
+        if self.config.mention_only_always_for_named and is_named:
+            return True
+        for identifier in identifiers:
+            if identifier in self.config.mention_only_rooms:
+                return True
+        return False
+
+    async def process(self):
+        """
+        Process media.
+        - if management room, identify replies and forward back to original messages.
+        - anything else, relay to management room.
+        """
+        if self.room.room_id == self.config.management_room_id:
+            await self.handle_management_room_media()
+        else:
+            await self.relay_to_management_room()
+
+    async def relay_to_management_room(self):
+        """Relay to the management room."""
+        # First check if we want to relay this
+        if self.is_mention_only_room([self.room.canonical_alias, self.room.room_id], self.room.is_named):
+            # skip media in mention only rooms for now
+            logger.debug(f"Skipping {media_name[self.media_type]} %s in room %s as it's set to only relay on mention and we were "
+                         "not mentioned.", self.event.event_id, self.room.room_id)
+            return
+
+        if self.config.anonymise_senders:
+            text = f"anonymous sent {media_name[self.media_type]}:"
+        else:
+            text = f"{self.event.sender} in {self.room.display_name} (`{self.room.room_id}`) sent {media_name[self.media_type]} " \
+                   f"{self.body}:"
+        response = await send_text_to_room(self.client, self.config.management_room, text, notice=True)
+        if type(response) == RoomSendResponse and response.event_id:
+            response = await send_media_to_room(
+                self.client,
+                self.config.management_room,
+                self.media_type,
+                self.body,
+                self.media_url,
+                self.media_file,
+                self.media_info,
+                reply_to_event_id=response.event_id
+            )
+
+            if type(response) == RoomSendResponse and response.event_id:
+                self.store.store_message(
+                    self.event.event_id,
+                    response.event_id,
+                    self.room.room_id,
+                )
+                logger.info(f"{media_name[self.media_type]} %s relayed to the management room", self.event.event_id)
+            else:
+                logger.error(f"Failed to relay {media_name[self.media_type]} %s to the management room", self.event.event_id)
+        else:
+            logger.error(f"Failed to relay {media_name[self.media_type]} %s to the management room", self.event.event_id)

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -59,6 +59,12 @@ middleman:
     success: "✔️"
     # Failure confirmation reaction symbol (Optional)
     fail: "❗"
+  # Relay media replies from management room to original sender directly
+  # When set to true, management room will send back media replies to original sender
+  # When set to false, media replies will not be sent back to original sender because 
+  # we can't normally prefix `!reply` in the message body
+  # (Optiona, default: false)
+  relay_management_media: false
 
 storage:
   # The database connection string


### PR DESCRIPTION
Hello,

This PR add support to relay media messages.
For the management room replies with media, we can't include `!reply` in media reply message and I can't think of method other than turning it on/off from config.
If you have suggestions I'll be happy to implement it.